### PR TITLE
move formatRegistration logic around to always create Slack text

### DIFF
--- a/internal/notification/message.go
+++ b/internal/notification/message.go
@@ -31,16 +31,16 @@ const (
 
 // Format whether to display a hyperlink for the registration or not
 func formatRegistration(ac jetspotter.AircraftOutput, notificationType string) string {
-	if ac.ImageURL == "" {
-		return ac.Registration
-	}
-
 	if notificationType == Markdown {
 		return fmt.Sprintf("[%s](%s)", ac.Registration, ac.ImageURL)
 	}
 
 	if notificationType == Slack {
 		return fmt.Sprintf("*Registration:* <%s|%s>", ac.ImageURL, ac.Registration)
+	}
+
+	if ac.ImageURL == "" {
+		return ac.Registration
 	}
 
 	return ac.Registration

--- a/internal/notification/message.go
+++ b/internal/notification/message.go
@@ -36,6 +36,10 @@ func formatRegistration(ac jetspotter.AircraftOutput, notificationType string) s
 	}
 
 	if notificationType == Slack {
+		if ac.ImageURL == "" {
+			return fmt.Sprintf("*Registration:* %s", ac.Registration)
+		}
+
 		return fmt.Sprintf("*Registration:* <%s|%s>", ac.ImageURL, ac.Registration)
 	}
 


### PR DESCRIPTION
By moving the `ImageURL` if statement down, this will create a Markdown and Slack message that both contain at least a minimal amount of text.