### PR TITLE
feat: allow filtering by altitude

### DIFF
--- a/cmd/jetspotter/jetspotter.go
+++ b/cmd/jetspotter/jetspotter.go
@@ -73,6 +73,9 @@ func jetspotterHandler(alreadySpottedAircraft *[]jetspotter.Aircraft, config con
 
 func HandleJetspotter(config configuration.Config) {
 	log.Printf("Spotting the following aircraft types within %d kilometers: %s", config.MaxRangeKilometers, config.AircraftTypes)
+	if config.MaxAltitudeFeet > 0 {
+		log.Printf("Only showing aircraft at or below %d feet.", config.MaxAltitudeFeet)
+	}
 
 	var alreadySpottedAircraft []jetspotter.Aircraft
 	for {

--- a/docs/snippets/config.snippet
+++ b/docs/snippets/config.snippet
@@ -9,6 +9,11 @@ type Config struct {
 	// MAX_RANGE_KILOMETERS 30
 	MaxRangeKilometers int
 
+	// Maximum altitude in feet that you want to spot aircraft at.
+	// Set to 0 to disable the filter.
+	// MAX_ALTITUDE_FEET 0
+	MaxAltitudeFeet int
+
 	// A comma seperated list of types that you want to spot
 	// If not set, 'ALL' will be used, which will disable the filter and show all aircraft within range.
 	// Full list can be found at https://www.icao.int/publications/doc8643/pages/search.aspx in 'Type Designator' column.

--- a/helm/jetspotter/templates/configmap.yaml
+++ b/helm/jetspotter/templates/configmap.yaml
@@ -8,6 +8,7 @@ data:
   LOCATION_LONGITUDE: {{ .Values.jetspotter.location.longitude | quote }}
   FETCH_INTERVAL:  {{ .Values.jetspotter.fetchInterval | quote }}
   MAX_RANGE_KILOMETERS: {{ .Values.jetspotter.maxRangeKilometers | quote }}
+  MAX_ALTITUDE_FEET: {{ .Values.jetspotter.maxAltitudeFeet | quote }}
   AIRCRAFT_TYPES: {{ .Values.jetspotter.aircraftTypes | join "," }}
   MAX_AIRCRAFT_SLACK_MESSAGE: {{ .Values.slack.maxAircraftPerMessage | quote }}
   DISCORD_COLOR_ALTITUDE: {{ .Values.discord.colorAltitude | quote }}

--- a/helm/jetspotter/values.yaml
+++ b/helm/jetspotter/values.yaml
@@ -7,7 +7,9 @@ jetspotter:
   fetchInterval: 60
   #  Maximum range in kilometers from the location that you want aircraft to be spotted.
   maxRangeKilometers: 30
-  # A comma seperated list of types that you want to spot
+  # Maximum altitude in feet that you want aircraft to be spotted. Set to 0 to disable.
+  maxAltitudeFeet: 0
+  # A comma separated list of types that you want to spot
   #  If not set, 'ALL' will be used, which will disable the filter and show all aircraft within range.
   # Full list can be found at https://www.icao.int/publications/doc8643/pages/search.aspx in 'Type Designator' column.
   aircraftTypes:

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -24,6 +24,11 @@ type Config struct {
 	// MAX_RANGE_KILOMETERS 30
 	MaxRangeKilometers int
 
+	// Maximum altitude in feet that you want to spot aircraft at.
+	// Set to 0 to disable the filter.
+	// MAX_ALTITUDE_FEET 0
+	MaxAltitudeFeet int
+
 	// A comma seperated list of types that you want to spot
 	// If not set, 'ALL' will be used, which will disable the filter and show all aircraft within range.
 	// Full list can be found at https://www.icao.int/publications/doc8643/pages/search.aspx in 'Type Designator' column.
@@ -84,6 +89,7 @@ const (
 	LocationLatitude         = "LOCATION_LATITUDE"
 	LocationLongitude        = "LOCATION_LONGITUDE"
 	MaxRangeKilometers       = "MAX_RANGE_KILOMETERS"
+	MaxAltitudeFeet          = "MAX_ALTITUDE_FEET"
 	MaxAircrfaftSlackMessage = "MAX_AIRCRAFT_SLACK_MESSAGE"
 	AircraftTypes            = "AIRCRAFT_TYPES"
 	FetchInterval            = "FETCH_INTERVAL"
@@ -131,6 +137,11 @@ func GetConfig() (config Config, err error) {
 	}
 
 	config.MaxRangeKilometers, err = strconv.Atoi(getEnvVariable(MaxRangeKilometers, "30"))
+	if err != nil {
+		return Config{}, err
+	}
+
+	config.MaxAltitudeFeet, err = strconv.Atoi(getEnvVariable(MaxAltitudeFeet, "0"))
 	if err != nil {
 		return Config{}, err
 	}

--- a/internal/jetspotter/jetspotter_test.go
+++ b/internal/jetspotter/jetspotter_test.go
@@ -33,6 +33,21 @@ var (
 		Callsign:  "JACKAL51",
 		PlaneType: "F16",
 	}
+
+	planesWithAltitude = []Aircraft{
+		{
+			Callsign:  "KHARMA11",
+			AltBaro:  4000,
+		},
+		{
+			Callsign:  "KHARMA12",
+			AltBaro:  9000,
+		},
+		{
+			Callsign:  "KHARMA13",
+		},
+	}
+
 	planes = []Aircraft{
 		{
 			Callsign:  "APEX11",
@@ -477,6 +492,25 @@ func TestConvertKilometersToMiles(t *testing.T) {
 	expected := 10
 	actual := convertKilometersToNauticalMiles(20)
 	if expected != actual {
+		t.Fatalf("expected '%v' to be the same as '%v'", expected, actual)
+	}
+}
+
+
+func TestFilterAircraftByAltitude(t *testing.T) {
+	expected := []Aircraft{
+		{
+			Callsign:  "KHARMA11",
+			AltBaro: 4000,
+		},
+	}
+
+	config := configuration.Config{
+		MaxAltitudeFeet: 5000,
+	}
+	actual := filterAircraftByAltitude(planesWithAltitude, config.MaxAltitudeFeet)
+
+	if !reflect.DeepEqual(expected, actual) {
 		t.Fatalf("expected '%v' to be the same as '%v'", expected, actual)
 	}
 }


### PR DESCRIPTION
Altitude filtering can be enableed by setting the MAX_ALTITUDE_FEET environment variable. If enabled, only aircraft at or below the maximum specifief altitude are displayed.

By default this value is set to 0, which effictevely disables this feature.

Closes https://github.com/vvanouytsel/jetspotter/issues/10