### PR TITLE
feat: add NTFY_TOKEN env var for ntfy server Bearer token auth

### DIFF
--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -92,6 +92,10 @@ type Config struct {
 	// URL of the ntfy server.
 	// NTFY_SERVER "https://ntfy.sh"
 	NtfyServer string
+
+	// Token for ntfy server authentication.
+	// NTFY_TOKEN ""
+	NtfyToken string
 }
 
 // Environment variable names
@@ -109,6 +113,7 @@ const (
 	GotifyURL              = "GOTIFY_URL"
 	NtfyTopic              = "NTFY_TOPIC"
 	NtfyServer             = "NTFY_SERVER"
+	NtfyToken              = "NTFY_TOKEN"
 	GotifyToken            = "GOTIFY_TOKEN"
 	MetricsPort            = "METRICS_PORT"
 	APIPort                = "API_PORT"
@@ -133,6 +138,7 @@ func GetConfig() (config Config, err error) {
 	config.GotifyURL = getEnvVariable(GotifyURL, "")
 	config.NtfyTopic = getEnvVariable(NtfyTopic, "")
 	config.NtfyServer = getEnvVariable(NtfyServer, "https://ntfy.sh")
+	config.NtfyToken = getEnvVariable(NtfyToken, "")
 	config.SlackWebHookURL = getEnvVariable(SlackWebhookURL, "")
 	config.DiscordWebHookURL = getEnvVariable(DiscordWebhookURL, "")
 	config.DiscordColorAltitude = getEnvVariable(DiscordColorAltitude, "true")

--- a/internal/notification/message.go
+++ b/internal/notification/message.go
@@ -14,6 +14,7 @@ type Notification struct {
 	Message interface{}
 	Type    string
 	URL     string
+	Token   string
 }
 
 const (
@@ -74,8 +75,17 @@ func SendMessage(notification Notification) error {
 		return err
 	}
 
-	resp, err := http.Post(notification.URL, "application/json",
-		bytes.NewReader(data))
+	req, err := http.NewRequest("POST", notification.URL, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if notification.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+notification.Token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/internal/notification/ntfy.go
+++ b/internal/notification/ntfy.go
@@ -37,6 +37,7 @@ func SendNtfyMessage(aircraft []jetspotter.Aircraft, config configuration.Config
 			Message: singleAircraftMessage,
 			Type:    Ntfy,
 			URL:     config.NtfyServer,
+			Token:   config.NtfyToken,
 		}
 
 		err = SendMessage(notification)


### PR DESCRIPTION
This commit adds support for authenticated ntfy servers that require Bearer token authentication.

Changes:
- Add NtfyToken field to Config struct in configuration.go
- Add NTFY_TOKEN environment variable constant
- Parse NTFY_TOKEN in GetConfig() function
- Add Token field to Notification struct in message.go
- Update SendMessage() to add Authorization: Bearer <token> header when Token is set, enabling authenticated ntfy endpoints
- Pass config.NtfyToken when creating ntfy notifications

Usage:
  NTFY_SERVER=https://ntfy.example.com   NTFY_TOPIC=mytopic   NTFY_TOKEN=tk_xxxxx   jetspotter

This allows self-hosted ntfy servers with authentication enabled to be used as notification backends.